### PR TITLE
Updated to correct file ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,10 @@ RUN mkdir -p /home/foundry/app
 WORKDIR /home/foundry/app
 COPY . .
 
+USER root
+RUN chown foundry /home/foundry/app/* -R
+
+USER foundry
+
 EXPOSE 30000
 CMD ["node", "/home/foundry/app/resources/app/main.js", "--headless", "--dataPath=/home/foundry/data" ]


### PR DESCRIPTION
I had to make this change in order to have all files in the /home/foundry/app directory owned by the user foundry.  They were previously owned by root.  This caused issues when trying to update 0.6.0 to 0.6.1 since the app user could not modify the files in /home/foundry/app