### PR TITLE
Update node image to version 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:16-alpine
 
 ENV UID=1000
 ENV GID=1000


### PR DESCRIPTION
The new Foundry VTT version requires node ≥ 14. The previous image was
version 12.